### PR TITLE
disable 'no-path-concat' rule for spa

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,7 @@ module.exports = {
     },
 
     // override any settings from the "parent" configuration
-    rules: {}
+    rules: {    
+        'no-path-concat': 'off'
+    }
 };


### PR DESCRIPTION
no sense to use path.join in web application